### PR TITLE
Mac OS X build fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 build/
 .git
 .coveralls.yml
+builderror.log

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,22 @@
         "csrc/enc/streams.cc"
       ],
       "cflags": [
-        "-std=c++11"
+        "-std=c++11",
+        "-ferror-limit=0"
+      ],
+      "conditions": [
+        [ 'OS!="win"', {
+          "cflags+": [ "-std=c++11" ],
+          "cflags_c+": [ "-std=c++11" ],
+          "cflags_cc+": [ "-std=c++11" ]
+        }],
+        [ 'OS=="mac"', {
+          "xcode_settings": {
+            "OTHER_CPLUSPLUSFLAGS": [ "-std=c++11", "-stdlib=libc++" ],
+            "OTHER_LDFLAGS": [ "-stdlib=libc++" ],
+            "MACOSX_DEPLOYMENT_TARGET": "10.7"
+          }
+        }]
       ]
     }
   ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,8 +26,7 @@
         "csrc/enc/streams.cc"
       ],
       "cflags": [
-        "-std=c++11",
-        "-ferror-limit=0"
+        "-std=c++11"
       ],
       "conditions": [
         [ 'OS!="win"', {


### PR DESCRIPTION
Builds successfully on Mac OS X 10.10.3 with Xcode and command line tools installed.

See: https://github.com/nfroidure/gulp-iconfont/issues/63