### PR TITLE
Add engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Convert TTF files to WOFF2 ones.",
   "main": "src/index.js",
   "browser": "jssrc/index.js",
+  "engines": {
+    "node": ">= 0.12"
+  },
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
Will trigger warnings when installing on node < 0.12 (also io.js).

See issue #8 