### PR TITLE
Include assert.h explicitly to fix windows build

### DIFF
--- a/csrc/woff2/port.h
+++ b/csrc/woff2/port.h
@@ -17,6 +17,8 @@
 #ifndef WOFF2_PORT_H_
 #define WOFF2_PORT_H_
 
+#include <assert.h>
+
 namespace woff2 {
 
 typedef unsigned int       uint32;


### PR DESCRIPTION
Fixes the error: C3861: 'assert': identifier not found on Windows

I am not sure how this fix behaves on unix systems, and/or if i need to wrap it inside a macro/directive