### PR TITLE
[Old repo PR] Testing OSX and Linux Travis CI test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
-language: node_js
-node_js:
-  - 0.12
-  - 4
-  - 5
+sudo: true
+language: bash
+
+os:
+  - linux
+  - osx
 
 before_install:
-# We need this line to have g++4.8 available in apt
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq gcc-4.8 g++-4.8
-# We want to compile with g++ 4.8 when rather than the default g++
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+# Run OS specific stuff
+  - ./scripts/travis.sh
+# Run NVM setup.
+  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then source ~/.bashrc; fi
+  - nvm --version
+  - nvm install 5
+  - node --version
+  - npm --version
 
 before_script:
-  - npm install --dev
+  - npm install
 
 script:
   - npm test

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ev
+if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+  echo "Running on OS X"
+  brew update
+else
+  echo "Running on Linux"
+  # We need this line to have g++4.8 available in apt
+  sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  sudo apt-get update -qq
+  sudo apt-get install -qq gcc-4.8 g++-4.8
+  # We want to compile with g++ 4.8 when rather than the default g++
+  sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+fi


### PR DESCRIPTION
## WIP
This will allow us to run tests on both OS X and Linux via Travis CI.

### What is currently working
As of `b321378` this is working. HOWEVER, there currently is a downside (that maybe we can script our way out of, needs more investigating), we only are testing one version of node. Latest stable `v5.x.x`.

This is because we had to change the `language` option to `bash` vs `node_js`. The reason for this is because we need to invoke the `nvm` commands at a later time (in OS X case, after it is actually installed). Otherwise, `nvm` will attempt to run before it's installed on OSX, and fail before even getting to `before_install`. 

So this forced us to change to `language: bash`. We then detect the OS version, and run OS specific code first, then the rest of the `before_install`, which includes installing NVM and installing a version of node.

### Things to do
- [x] Get Travis CI running tests in both Linux and OS X.
- [ ] Have the Linux runs use latest Travis CI containers vs the legacy setup. (Speeds up builds, downside is no `sudo`, however see: `apt`).
- [ ] Investigate running several node version checks and not just `v5.x.x`. 