### PR TITLE
Build instead of rebuild on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "make": "node-gyp build",
     "emcc": "miniquery -p \"targets.#.sources.#\" ./binding.gyp | grep -v \"csrc/addon.cc\" | xargs emcc --bind -o jssrc/ttf2woff2.js -O3 --memory-init-file 0 -s \"TOTAL_MEMORY=536870912\" -s \"ALLOW_MEMORY_GROWTH=1\" --post-js jssrc/post.js csrc/fallback.cc",
     "emcc-debug": "miniquery -p \"targets.#.sources.#\" ./binding.gyp | grep -v \"csrc/addon.cc\" | xargs emcc --bind -o jssrc/ttf2woff2.js -s \"ALLOW_MEMORY_GROWTH=1\" -s \"ASSERTIONS=1\" --post-js jssrc/post.js csrc/fallback.cc",
-    "install": "(node-gyp rebuild > builderror.log) || (exit 0)"
+    "install": "((node-gyp configure && node-gyp build) > builderror.log) || (exit 0)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When installing other modules, the bindings are rebuilt every time. So it takes more than 20 seconds to install any package on a project using this library.

This PR avoids rebuilding the bindings.