### PR TITLE
node-gyp 6.0.0 upgrade (resolves python2 dependency)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,9 +264,9 @@
       "dev": true
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "circular-json": {
       "version": "0.3.3",
@@ -445,6 +445,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "env-paths": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+      "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -779,11 +784,11 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.6.0"
       }
     },
     "fs.realpath": {
@@ -1252,9 +1257,9 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -1270,11 +1275,11 @@
       }
     },
     "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.9.0"
       }
     },
     "mkdirp": {
@@ -1386,20 +1391,20 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
-      "integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.0.0.tgz",
+      "integrity": "sha512-Qz6Xda2bKzdsooXITarGf2uaCJcYh7ua+jeRMifBFmTz0peo0JW6IjpqELlX+ZiHXphsKzISgaCsZeQch5a+NA==",
       "requires": {
+        "env-paths": "^1.0.0",
         "glob": "^7.0.3",
         "graceful-fs": "^4.1.2",
         "mkdirp": "^0.5.0",
         "nopt": "2 || 3",
         "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
         "request": "^2.87.0",
         "rimraf": "2",
         "semver": "~5.3.0",
-        "tar": "^4.4.8",
+        "tar": "^4.4.12",
         "which": "1"
       }
     },
@@ -1486,24 +1491,11 @@
         "wordwrap": "~1.0.0"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1899,17 +1891,17 @@
       }
     },
     "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "yallist": "^3.0.3"
       }
     },
     "text-table": {
@@ -2062,9 +2054,9 @@
       }
     },
     "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yerror": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bindings": "^1.3.0",
     "bufferstreams": "^2.0.1",
     "nan": "^2.10.0",
-    "node-gyp": "^4.0.0"
+    "node-gyp": "^6.0.0"
   },
   "devDependencies": {
     "coveralls": "^3.0.1",


### PR DESCRIPTION
Currently ttf2woff2 requires node-gyp 4.0, which requires python2 (instead of python3). This has led to issues like https://github.com/nfroidure/ttf2woff2/issues/37 and https://github.com/nfroidure/ttf2woff2/issues/28

Earlier this month node-gyp released version 6.0.0, which accepts python3 (https://github.com/nodejs/node-gyp/pull/1844). This PR upgrades the package.json and package-lock.json to node-gyp 6.0.0.

https://github.com/nodejs/node-gyp/blob/master/CHANGELOG.md

I've verified it builds with the new node-gyp version:

```
$ node-gyp --version
v6.0.0

$ node-gyp configure
gyp info it worked if it ends with ok
gyp info using node-gyp@6.0.0
gyp info using node@10.17.0 | linux | x64
gyp info find Python using Python version 3.6.8 found at "/usr/bin/python3"
gyp info spawn /usr/bin/python3
gyp info spawn args [ '/home/neil/git/ttf2woff2/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/home/neil/git/ttf2woff2/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/home/neil/git/ttf2woff2/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/home/neil/.cache/node-gyp/10.17.0/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/home/neil/.cache/node-gyp/10.17.0',
gyp info spawn args   '-Dnode_gyp_dir=/home/neil/git/ttf2woff2/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/home/neil/.cache/node-gyp/10.17.0/<(target_arch)/node.lib',
gyp info spawn args   '-Dmodule_root_dir=/home/neil/git/ttf2woff2',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.' ]
gyp info ok 

$ node-gyp build
gyp info it worked if it ends with ok
gyp info using node-gyp@6.0.0
gyp info using node@10.17.0 | linux | x64
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory '/home/neil/git/ttf2woff2/build'
  CXX(target) Release/obj.target/addon/csrc/addon.o
  CXX(target) Release/obj.target/addon/csrc/woff2/glyph.o
  CXX(target) Release/obj.target/addon/csrc/woff2/font.o
  CXX(target) Release/obj.target/addon/csrc/woff2/normalize.o
  CXX(target) Release/obj.target/addon/csrc/woff2/table_tags.o
  CXX(target) Release/obj.target/addon/csrc/woff2/transform.o
  CXX(target) Release/obj.target/addon/csrc/woff2/variable_length.o
  CXX(target) Release/obj.target/addon/csrc/woff2/woff2_common.o
  CXX(target) Release/obj.target/addon/csrc/woff2/woff2_enc.o
  CXX(target) Release/obj.target/addon/csrc/enc/backward_references.o
  CXX(target) Release/obj.target/addon/csrc/enc/block_splitter.o
  CXX(target) Release/obj.target/addon/csrc/enc/brotli_bit_stream.o
  CXX(target) Release/obj.target/addon/csrc/enc/encode.o
  CXX(target) Release/obj.target/addon/csrc/enc/encode_parallel.o
  CXX(target) Release/obj.target/addon/csrc/enc/entropy_encode.o
  CXX(target) Release/obj.target/addon/csrc/enc/histogram.o
  CXX(target) Release/obj.target/addon/csrc/enc/literal_cost.o
  CXX(target) Release/obj.target/addon/csrc/enc/metablock.o
  CXX(target) Release/obj.target/addon/csrc/enc/streams.o
  SOLINK_MODULE(target) Release/obj.target/addon.node
  COPY Release/addon.node
make: Leaving directory '/home/neil/git/ttf2woff2/build'
gyp info ok 
```