### PR TITLE
Add prepare script to allow installation from Git; remove unneeded install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "make": "node-gyp build",
     "metapak": "metapak",
     "precz": "npm t && npm run lint && npm run metapak -- -s && npm run compile",
+    "prepare": "npm run compile",
     "prettier": "prettier --write 'src/**/*.js' 'jssrc/**/*.js'",
     "preversion": "npm run lint && npm test && npm t && npm run metapak -- -s && npm run compile",
     "test": "npm run jest",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "cz": "env NODE_ENV=${NODE_ENV:-cli} git cz",
     "emcc": "miniquery -p \"targets.#.sources.#\" ./binding.gyp | grep -v \"csrc/addon.cc\" | xargs emcc --bind -o jssrc/ttf2woff2.js -O3 --memory-init-file 0 -s \"TOTAL_MEMORY=536870912\" -s \"ALLOW_MEMORY_GROWTH=1\" -s BINARYEN_ASYNC_COMPILATION=0 -s 'EXTRA_EXPORTED_RUNTIME_METHODS=[\"getValue\", \"writeArrayToMemory\"]' --post-js jssrc/post.js csrc/fallback.cc",
     "emcc-debug": "miniquery -p \"targets.#.sources.#\" ./binding.gyp | grep -v \"csrc/addon.cc\" | xargs emcc --bind -o jssrc/ttf2woff2.js -s \"ALLOW_MEMORY_GROWTH=1\" -s \"ASSERTIONS=1\" -s BINARYEN_ASYNC_COMPILATION=0 -s 'EXTRA_EXPORTED_RUNTIME_METHODS=[\"getValue\", \"writeArrayToMemory\"]' --post-js jssrc/post.js csrc/fallback.cc",
-    "install": "((node-gyp configure && node-gyp build) > builderror.log) || (exit 0)",
     "jest": "NODE_ENV=test jest",
     "lint": "eslint 'src/**/*.js' 'jssrc/**/*.js'",
     "make": "node-gyp build",


### PR DESCRIPTION
### Proposed changes
- build: add `prepare` script to allow installation from Git

  When installing from a Git URL rather than from the NPM registry, we need to build the `dist` directory using Babel.

- build: remove unneeded install script

  `npm` already runs `node-gyp rebuild` on `install`, and [recommends against using an `install` script](https://docs.npmjs.com/cli/v7/using-npm/scripts#best-practices) for this.

### Code quality
- [ ] I made some tests for my changes
- [ ] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the `package.json` file. Beware to use the same format than for the author field
 for the entries so that you'll get a mention in the `README.md` with a link to your website.

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license

### Join
- [ ] I wish to join the core team
- [x] I agree that with great powers comes responsibilities
- [x] I'm a nice person

My NPM username: andersk
